### PR TITLE
fix: #34 invalid json body returns 500 instead of 400

### DIFF
--- a/src/middlewares/errorHandler.middleware.ts
+++ b/src/middlewares/errorHandler.middleware.ts
@@ -13,6 +13,16 @@ export default function errorHandler(error: unknown, req: Request, res: Response
     error: "Internal server error",
   };
 
+  // invalid payload/json body
+  if (error instanceof SyntaxError && "body" in error) {
+    shouldLogError = false;
+    statusCode = 400;
+    responsePayload = {
+      status: "fail",
+      error: "Invalid JSON payload",
+    };
+  }
+
   // Zod validation errors
   if (error instanceof ZodError) {
     shouldLogError = false;


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix invalid JSON body returning 500 instead of 400

- Add proper error handling for malformed JSON requests

- Return appropriate client error status code


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Invalid JSON Request"] --> B["SyntaxError with body"] --> C["Return 400 Bad Request"]
  A --> D["Previous Behavior"] --> E["Return 500 Internal Error"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>errorHandler.middleware.ts</strong><dd><code>Add JSON syntax error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/middlewares/errorHandler.middleware.ts

<ul><li>Add check for <code>SyntaxError</code> with <code>body</code> property<br> <li> Set status code to 400 for invalid JSON payloads<br> <li> Return "Invalid JSON payload" error message<br> <li> Disable error logging for client-side JSON errors</ul>


</details>


  </td>
  <td><a href="https://github.com/Andrei-Boghiu/nexml-playground-express-service-api/pull/37/files#diff-7d0b26da3d33e9f4252935d0263b1721bbbda9bfa59c3540c55d98b84d9aaf31">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

